### PR TITLE
vanilla rot clamp

### DIFF
--- a/SquAPI.lua
+++ b/SquAPI.lua
@@ -302,7 +302,7 @@ function squapi.ear:new(leftEar, rightEar, rangeMultiplier, horizontalEars, bend
       local vel = math.min(math.max(-0.75, squassets.forwardVel()), 0.75)
       local yvel = math.min(math.max(-1.5, squassets.verticalVel()), 1.5) * 5
       local svel = math.min(math.max(-0.5, squassets.sideVel()), 0.5)
-      local headrot = squassets.getHeadRot()
+      local headrot = squassets.clampedRot(vanilla_model.HEAD)
       local bend = self.bendStrength
       if headrot[1] < -22.5 then bend = -bend end
 
@@ -647,7 +647,7 @@ function squapi.eye:new(element, leftDistance, rightDistance, upDistance, downDi
   ---Run tick function on eye
   function self:tick()
     if self.enabled then
-      local headrot = squassets.getHeadRot()
+      local headrot = squassets.clampedRot(vanilla_model.HEAD)
       headrot[2] = math.max(math.min(50, headrot[2]), -50)
 
       --parabolic curve so that you can control the middle position of the eyes.
@@ -866,10 +866,10 @@ function squapi.leg:new(element, strength, isRight, keepPosition)
   ---@return Vector3 #Vanilla leg position
   function self:getVanilla()
     if self.isRight then
-      self.rot = vanilla_model.RIGHT_LEG:getOriginRot()
+      self.rot = squassets.clampedRot(vanilla_model.RIGHT_LEG)
       self.pos = vanilla_model.RIGHT_LEG:getOriginPos()
     else
-      self.rot = vanilla_model.LEFT_LEG:getOriginRot()
+      self.rot = squassets.clampedRot(vanilla_model.LEFT_LEG)
       self.pos = vanilla_model.LEFT_LEG:getOriginPos()
     end
     return self.rot, self.pos
@@ -910,9 +910,9 @@ function squapi.arm:new(element, strength, isRight, keepPosition)
   ---@return Vector3 #Vanilla arm position
   function self:getVanilla()
     if self.isRight then
-      self.rot = vanilla_model.RIGHT_ARM:getOriginRot()
+      self.rot = squassets.clampedRot(vanilla_model.RIGHT_ARM)
     else
-      self.rot = vanilla_model.LEFT_ARM:getOriginRot()
+      self.rot = squassets.clampedRot(vanilla_model.LEFT_ARM)
     end
     self.pos = -vanilla_model.LEFT_ARM:getOriginPos()
     return self.rot, self.pos
@@ -1039,7 +1039,7 @@ function squapi.smoothHead:new(element, strength, tilt, speed, keepOriginalHeadP
   ---Run tick function on smooth head
   function self:tick()
     if self.enabled then
-      local vanillaHeadRot = squassets.getHeadRot()
+      local vanillaHeadRot = squassets.clampedRot(vanilla_model.HEAD)
 
       self.headRot[1] = self.headRot[1] + (vanillaHeadRot[1] - self.headRot[1]) * self.speed
       self.headRot[2] = self.headRot[2] + (vanillaHeadRot[2] - self.headRot[2]) * self.speed

--- a/SquAssets.lua
+++ b/SquAssets.lua
@@ -68,9 +68,9 @@ function squassets.sideVel()
   return (player:getVelocity() * matrices.rotation3(0, player:getRot().y, 0)).x
 end
 
---returns a cleaner vanilla head rotation value to use
-function squassets.getHeadRot()
-  return (vanilla_model.HEAD:getOriginRot() + 180) % 360 - 180
+--returns a cleaner vanilla rotation value to use
+function squassets.clampedRot(v)
+  return (v:getOriginRot() + 180) % 360 - 180
 end
 
 --Math Functions


### PR DESCRIPTION
- changed `getHeadRot()` to `clampedRot(v)` as to support multiple `vanilla_model` parts
- clamped vanilla leg and arm rotations

It may be a good idea to keep `getHeadRot` and have it hook into `clampedRot` in case users are currently using `getHeadRot`.
Additionally, renaming `clampedRot` to `getClampedRot` is also a good idea.

As long as vanilla leg and arm rotations are clamped, I'm happy!